### PR TITLE
Feat/add dblp search

### DIFF
--- a/mcp_server/search_scholar/server.py
+++ b/mcp_server/search_scholar/server.py
@@ -3,7 +3,7 @@ import os
 import http.client
 import json
 import arxiv
-from typing import List, Dict, Literal, Union
+from typing import List, Dict, Union
 import httpx
 
 
@@ -142,7 +142,6 @@ async def search_dblp_papers(query: str, max_results: int = 5) -> str:
     Returns:
         A string containing multiple search results separated by '---'. 
         Each result includes: Title, Authors, Venue (with Year), Type, and Link.
-    !ATTENTION! You can read the pdf url with web parse tools after you have searched the pdf_url
     """
     url = "https://dblp.org/search/publ/api"
     hits = await _fetch_dblp(url, query, max_results)
@@ -200,7 +199,7 @@ async def search_dblp_authors(query: str, max_results: int = 5) -> str:
         max_results: Max number of authors to return (default 5).
 
     Returns:
-        A formatted list of matching authors, including their Name, Context (Affiliations/Awards), and Profile Link.
+        A formatted string containing matching author profiles, including Name, Context (Affiliations/Awards), and Profile Link.
     """
     url = "https://dblp.org/search/author/api"
     hits = await _fetch_dblp(url, query, max_results)
@@ -243,7 +242,7 @@ async def search_dblp_venues(query: str, max_results: int = 5) -> str:
         max_results: Max number of venues to return (default 5).
         
     Returns:
-        A list of matching venues containing Name, Acronym, and Type (Conference/Journal).
+        A formatted string containing matching venues, including Name, Acronym, and Type (Conference/Journal).
     """
     url = "https://dblp.org/search/venue/api"
     hits = await _fetch_dblp(url, query, max_results)


### PR DESCRIPTION
## 摘要
增加 DBLP 搜索工具 (`search_dblp_papers`, `search_dblp_authors`, `search_dblp_venues`)，支持对计算机科学领域的文献、学者和会议进行检索。

## 主要变更
 **新增工具**:
   -  `search_dblp_papers`: 搜索论文/学位论文，返回详细书目信息，包括：**标题 (Title)、作者列表 (Authors)、发表会议/年份 (Venue & Year)、文献类型 (Type) 及 DOI/PDF 直链**
   - `search_dblp_authors`: 搜索研究人员，返回**姓名 (Name)、机构与奖项上下文 (Context/Affiliations) 及个人主页链接**
   - `search_dblp_venues`: 搜索会议/期刊，返回**全称 (Name)、缩写 (Acronym)、类型 (Conference/Journal) 及链接**

## 输出示例
```text
搜论文：
📄 [Paper] Attentional Transfer is All You Need: Technology-aware Layout Pattern Generation.
👥 Authors: Xiaopeng Zhang 0009, Haoyu Yang, Evangeline F. Y. Young
🏛 Venue: DAC (2021)
📌 Type: Conference and Workshop Papers
🔗 Link: https://doi.org/10.1109/DAC18074.2021.9586227

搜作者：
🧑‍🔬 [Author] Yann LeCun
🏢 Context: New York University, Courant Institute of Mathematical Sciences, USA; Facebook; Turing Award
🔗 Profile: https://dblp.org/pid/l/YannLeCun

搜会议：
🏛 [Venue] IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR)
📌 Type: Conference or Workshop
🔗 Link: https://dblp.org/db/conf/cvpr/
```
Fixes #20 