### PR TITLE
feat: add Tavily as parallel web search option in search_web

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -71,6 +71,7 @@ env:
   ZHIPU_API_KEY: your-api-key
   ZHIPU_BASE_URL: "https://open.bigmodel.cn/api/paas/v4/"
   SERPER_API_KEY: your-api-key
+  TAVILY_API_KEY: your-api-key
   MEMOS_API_KEY: your-api-key
   MEMOS_BASE_URL: "https://memos.memtensor.cn/api/openmem/v1"
   MEMOS_USER_ID: your_user_id

--- a/mcp_server/search_web/server.py
+++ b/mcp_server/search_web/server.py
@@ -3,6 +3,7 @@ import os
 import http.client
 import json
 from mcp.server.fastmcp import FastMCP
+from tavily import TavilyClient
 
 mcp = FastMCP("web-search")
 
@@ -100,6 +101,65 @@ def web_parse(url: str) -> str:
     conn.request("POST", "/", payload, headers)
     data = conn.getresponse().read().decode("utf-8")
     return data
+
+
+@mcp.tool()
+def tavily_search(query: str, search_depth: str = "basic", topic: str = "general", max_results: int = 5) -> str:
+    """
+    [Tavily Web Search] Perform a web search using Tavily, an AI-optimized search engine.
+
+    Returns comprehensive search results including titles, URLs, content snippets, and relevance scores.
+    Tavily results are optimized for LLM consumption and include clean, relevant content.
+
+    **AI Usage Guideline:**
+    1.  Use this as an alternative to `google_search` for general web queries.
+    2.  Results include content snippets directly, but for full page content use `tavily_extract` or `web_parse`.
+
+    Args:
+        query: The search query, which can be in any language.
+        search_depth: Search depth - "basic" (fast, 1 credit) or "advanced" (thorough, 2 credits). Defaults to "basic".
+        topic: Search topic category - "general", "news", or "finance". Defaults to "general".
+        max_results: Maximum number of results to return (1-20). Defaults to 5.
+
+    Returns:
+        A JSON string containing search results with titles, URLs, content, and relevance scores.
+    """
+    client = TavilyClient(api_key=os.getenv("TAVILY_API_KEY"))
+    response = client.search(
+        query=query,
+        search_depth=search_depth,
+        topic=topic,
+        max_results=max_results,
+    )
+    return json.dumps(response, ensure_ascii=False)
+
+
+@mcp.tool()
+def tavily_extract(urls: list[str], query: str = "") -> str:
+    """
+    [Tavily Content Extractor] Extract clean, readable content from one or more web page URLs using Tavily.
+
+    This tool retrieves the full content of specified web pages, stripped of irrelevant elements.
+    It can be used as an alternative to `web_parse` for extracting page content.
+
+    **AI Usage Guideline:**
+    1.  Use after `tavily_search` or `google_search` to get full content from specific URLs.
+    2.  Optionally provide a query to rerank extracted content chunks by relevance.
+    3.  Accepts up to 20 URLs at once for batch extraction.
+
+    Args:
+        urls: A list of URLs to extract content from (max 20).
+        query: Optional query to rerank extracted chunks by relevance.
+
+    Returns:
+        A JSON string containing the extracted content for each URL.
+    """
+    client = TavilyClient(api_key=os.getenv("TAVILY_API_KEY"))
+    kwargs = {"urls": urls}
+    if query:
+        kwargs["query"] = query
+    response = client.extract(**kwargs)
+    return json.dumps(response, ensure_ascii=False)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "pytest-html>=4.2.0",
     "seedir>=0.5.1",
     "nest-asyncio>=1.6.0",
+    "tavily-python>=0.5.0",
 ]
 
 [[tool.uv.index]]


### PR DESCRIPTION
## Summary

Adds Tavily as a configurable parallel web search option alongside the existing Serper (`google_search`, `web_parse`) and Zhipu AI (`web_search_chinese`) tools in the `search_web` MCP server.

### What changed and why

Tavily provides an AI-optimized search API with built-in content extraction, making it a natural complement to the existing search providers. This is an **additive** change — all existing tools remain untouched.

### New MCP tools

- **`tavily_search`** — Web search via Tavily with configurable `search_depth`, `topic`, and `max_results` parameters
- **`tavily_extract`** — Batch URL content extraction via Tavily (up to 20 URLs), with optional relevance-based reranking via `query` parameter

## Files changed

- `mcp_server/search_web/server.py` — Added `TavilyClient` import and two new MCP tools (`tavily_search`, `tavily_extract`)
- `pyproject.toml` — Added `tavily-python>=0.5.0` dependency
- `config/config.example.yaml` — Added `TAVILY_API_KEY` env var entry

## Dependency changes

- Added `tavily-python>=0.5.0` to `pyproject.toml`

## Environment variable changes

- Added `TAVILY_API_KEY` to `config/config.example.yaml` under `env:` section

## Notes for reviewers

- Existing `google_search`, `web_parse`, and `web_search_chinese` tools are completely unchanged
- The agent can choose between Tavily and Serper tools based on context
- `TAVILY_API_KEY` must be set for the new tools to function


### Automated Review

- Passed after 1 attempt(s)
- Final review: The migration correctly adds `tavily_search` and `tavily_extract` as new MCP tools to the search_web server in a purely additive fashion. All three files from the plan are updated: `server.py` gains both tools with correct TavilyClient SDK usage, `pyproject.toml` gains the `tavily-python>=0.5.0` dependency, and `config.example.yaml` documents the `TAVILY_API_KEY`. Existing tools (`web_search_chinese`, `google_search`, `web_parse`) are untouched. No regressions found. Two minor issues noted but neither blocks approval.
