### PR TITLE
feat: add Tavily as parallel academic search option in search_scholar

### DIFF
--- a/mcp_server/search_scholar/server.py
+++ b/mcp_server/search_scholar/server.py
@@ -6,10 +6,13 @@ import httpx
 import asyncio
 from typing import List, Dict, Union
 from mcp.server.fastmcp import FastMCP
+from tavily import TavilyClient
 
 
 client = arxiv.Client()
 mcp = FastMCP("scholar-search")
+
+tavily_client = TavilyClient(api_key=os.getenv("TAVILY_API_KEY", ""))
 
 
 @mcp.tool()
@@ -106,6 +109,37 @@ def google_scholar_search(query: str) -> str:
     conn.request("POST", "/scholar", payload, headers)
     data = conn.getresponse().read().decode("utf-8")
     return data
+
+
+@mcp.tool()
+def tavily_academic_search(query: str, max_results: int = 5) -> str:
+    """Perform an academic/scholarly web search using Tavily as an alternative to Google Scholar.
+
+    Uses Tavily's advanced search depth for higher relevance on academic queries.
+
+    Args:
+        query (str): Search query for academic papers, authors, or topics.
+        max_results (int): Maximum number of results to return, default 5.
+
+    Returns:
+        str: JSON string with search results including title, url, and content snippet.
+    !ATTENTION! You can read the pdf url with web parse tools after you have searched the pdf_url
+    """
+    response = tavily_client.search(
+        query=query,
+        max_results=max_results,
+        search_depth="advanced",
+        topic="general",
+    )
+    results = []
+    for r in response.get("results", []):
+        results.append({
+            "title": r.get("title", ""),
+            "url": r.get("url", ""),
+            "content": r.get("content", ""),
+            "score": r.get("score", 0),
+        })
+    return json.dumps(results, ensure_ascii=False, indent=2)
 
 
 # dblp内部辅助函数

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "pytest-html>=4.2.0",
     "seedir>=0.5.1",
     "nest-asyncio>=1.6.0",
+    "tavily-python>=0.5.0",
 ]
 
 [[tool.uv.index]]


### PR DESCRIPTION
## Summary

Adds Tavily as a configurable parallel search option alongside the existing Google Scholar (Serper) tool in the `search_scholar` MCP server.

### What changed
- **New `tavily_academic_search` tool** in `mcp_server/search_scholar/server.py` — uses `TavilyClient.search()` with `search_depth='advanced'` and `topic='general'` to provide an alternative academic web search
- **Added `tavily-python>=0.5.0`** dependency to `pyproject.toml`
- Existing tools (`google_scholar_search`, `arxiv_search_by_author`, `arxiv_search_by_content`, DBLP tools) are **unchanged**

### Files changed
- `mcp_server/search_scholar/server.py` — added TavilyClient import, client initialization, and `tavily_academic_search` tool
- `pyproject.toml` — added `tavily-python>=0.5.0` to dependencies

### Environment variable changes
- Requires `TAVILY_API_KEY` environment variable to be set

### Notes for reviewers
- This is an **additive** change — no existing functionality is modified or removed
- The Tavily client is initialized at module level using `TAVILY_API_KEY` env var
- The new tool returns JSON-formatted results with title, url, content snippet, and relevance score


### Automated Review

- Passed after 1 attempt(s)
- Final review: The implementation correctly adds a `tavily_academic_search` MCP tool to the scholar server as a parallel option alongside the existing `google_scholar_search`. The Tavily SDK usage is valid, all existing tools (arXiv, DBLP, Serper Scholar) are untouched, and the code style is consistent with the codebase. One minor concern: `pyproject.toml` adds `tavily-python>=0.5.0` which the migration plan notes is already covered by the prerequisite `search-web-add-tavily` unit — this is a potential duplicate when both PRs land on main and will need a trivial resolution at merge time.
